### PR TITLE
Fix info dict key error with latest MetaDrive

### DIFF
--- a/copo_code/copo/algo_svo/svo_env.py
+++ b/copo_code/copo/algo_svo/svo_env.py
@@ -5,14 +5,15 @@ from collections import defaultdict
 from math import cos, sin
 
 import numpy as np
-from copo.utils import get_rllib_compatible_env
 from gym.spaces import Box
-from metadrive.envs.marl_envs.marl_inout_roundabout import LidarStateObservationMARound
 from metadrive.envs.marl_envs.marl_tollgate import TollGateObservation, MultiAgentTollgateEnv
+from metadrive.obs.state_obs import LidarStateObservation
 from metadrive.utils import get_np_random, norm, clip
 
+from drivingforce.copo.utils import get_rllib_compatible_env
 
-class SVOObsForRound(LidarStateObservationMARound):
+
+class SVOObsForRound(LidarStateObservation):
     @property
     def observation_space(self):
         space = super(SVOObsForRound, self).observation_space
@@ -22,7 +23,23 @@ class SVOObsForRound(LidarStateObservationMARound):
         space = Box(
             low=np.array([space.low[0]] * length),
             high=np.array([space.high[0]] * length),
-            shape=(length, ),
+            shape=(length,),
+            dtype=space.dtype
+        )
+        return space
+
+
+class SVOObsForRoundForTollgate(TollGateObservation):
+    @property
+    def observation_space(self):
+        space = super(SVOObsForRoundForTollgate, self).observation_space
+        assert isinstance(space, Box)
+        assert len(space.shape) == 1
+        length = space.shape[0] + 1
+        space = Box(
+            low=np.array([space.low[0]] * length),
+            high=np.array([space.high[0]] * length),
+            shape=(length,),
             dtype=space.dtype
         )
         return space

--- a/copo_code/copo/algo_svo/svo_env.py
+++ b/copo_code/copo/algo_svo/svo_env.py
@@ -10,7 +10,7 @@ from metadrive.envs.marl_envs.marl_tollgate import TollGateObservation, MultiAge
 from metadrive.obs.state_obs import LidarStateObservation
 from metadrive.utils import get_np_random, norm, clip
 
-from drivingforce.copo.utils import get_rllib_compatible_env
+from copo.utils import get_rllib_compatible_env
 
 
 class SVOObsForRound(LidarStateObservation):

--- a/copo_code/copo/callbacks.py
+++ b/copo_code/copo/callbacks.py
@@ -34,7 +34,7 @@ class MultiAgentDrivingCallbacks(DefaultCallbacks):
             k = agent_id
             info = episode.last_info_for(k)
             if info:
-                if "velocity" not in info:
+                if "step_reward" not in info:
                     continue
                 episode.user_data["velocity"][k].append(info["velocity"])
                 episode.user_data["steering"][k].append(info["steering"])


### PR DESCRIPTION
In this PR, I will fix:

* Wrong state observation. The path to StateObservation is wrong with latest MetaDrive and we have to change the import code for this.
* Wrong info dict. In latest MetaDrive, in the first step of a newly spawn agent the info dict contains velocity entries like: `{velocity=0.0}`. Therefore in the `DrivingCallback`, the criterion to check whether the info dict is came from a newly spawn agent `if "velocity" in info` become invalid since velocity is there even the agent is just born. I changed this criterion to `if "step_reward" in info` now!

Related to #14 

